### PR TITLE
Removing unnecessary import, Deque

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate time;
 
-use std::collections::{ Deque, RingBuf };
+use std::collections::RingBuf;
 
 /// Measures Frames Per Second (FPS).
 pub struct FPSCounter {


### PR DESCRIPTION
std::collections::Deque is gone and it is not used in the project. So, removing it.
