### PR TITLE
Using `clock_ticks` instead of `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "fps_counter"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "eddyb"
@@ -18,8 +18,7 @@ homepage = "https://github.com/pistondevelopers/fps_counter"
 name = "fps_counter"
 path = "src/lib.rs"
 
-[dependencies.time]
-
-#git = "http://github.com/rust-lang/time"
-version = "*"
+[dependencies.clock_ticks]
+git = "https://github.com/tomaka/clock_ticks"
+#version = "0.0.5"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 //! A Frames Per Second counter.
 
-extern crate time;
+extern crate clock_ticks;
 
 use std::collections::VecDeque;
 
 /// Measures Frames Per Second (FPS).
 pub struct FPSCounter {
     /// The last registered frames.
-    last_second_frames: VecDeque<time::Timespec>
+    last_second_frames: VecDeque<u64>
 }
 
 impl FPSCounter {
@@ -20,8 +20,8 @@ impl FPSCounter {
 
     /// Updates the FPSCounter and returns number of frames.
     pub fn tick(&mut self) -> usize {
-        let now = time::now().to_timespec();
-        let a_second_ago = time::Timespec::new(now.sec - 1, now.nsec);
+        let now = clock_ticks::precise_time_ns();
+        let a_second_ago = now - 1_000_000_000;
 
         while self.last_second_frames.front().map_or(false, |t| *t < a_second_ago) {
             self.last_second_frames.pop_front();


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/fps_counter/issues/17