### PR TITLE
Replaced deprecated clock_ticks with time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "fps_counter"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "eddyb"
@@ -19,5 +19,5 @@ name = "fps_counter"
 path = "src/lib.rs"
 
 [dependencies]
-clock_ticks = "0.0.6"
+time = "0.1.33"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! A Frames Per Second counter.
 
-extern crate clock_ticks;
+extern crate time;
 
 use std::collections::VecDeque;
 
@@ -20,7 +20,7 @@ impl FPSCounter {
 
     /// Updates the FPSCounter and returns number of frames.
     pub fn tick(&mut self) -> usize {
-        let now = clock_ticks::precise_time_ns();
+        let now = time::precise_time_ns();
         let a_second_ago = now - 1_000_000_000;
 
         while self.last_second_frames.front().map_or(false, |t| *t < a_second_ago) {


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/fps_counter/issues/21

- Bumped to 0.2.0